### PR TITLE
Fix nvram_getall error when reading an empty nvram file.

### DIFF
--- a/nvram.c
+++ b/nvram.c
@@ -482,7 +482,8 @@ int nvram_getall(char *buf, size_t len) {
             return E_FAILURE;
         }
 
-        if (!(ret = fread(temp, sizeof(*temp), BUFFER_SIZE, f))) {
+        ret = fread(temp, sizeof(*temp), BUFFER_SIZE, f);
+        if (ferror(f)) {
             fclose(f);
             closedir(dir);
             sem_unlock();


### PR DESCRIPTION
Running the nvram userspace tool with command 'nvram show' should output all nvram keys and their values. Currently the function that's used for this, nvram_getall, gives an error on the first empty value it encounters. Many nvram keys remain unpopulated, and some are intentionally set and unset for message handling. This commit changes the behavior to read the file and then to only abort if a read error occurred. This prevents the common use case of empty nvram variables from causing an error.