### PR TITLE
Fix retrieving multi-line nvram values.

### DIFF
--- a/nvram.c
+++ b/nvram.c
@@ -391,8 +391,10 @@ int nvram_get_buf(const char *key, char *buf, size_t sz) {
         return E_FAILURE;
     }
 
-    if (fgets(buf, sz, f) != buf) {
-        buf[0] = '\0';
+    buf[0] = '\0';
+    char tmp[sz];
+    while(fgets(tmp, sz, f)) {
+        strncat (buf, tmp, sz);
     }
     fclose(f);
     sem_unlock();


### PR DESCRIPTION
Certain NVRAM variables such as those containing RSA keys can hold values spanning multiple lines which may include one or more carriage returns. With this modification it is now possible to retrieve the complete contents of the variable rather than the first line only.